### PR TITLE
Update Dodge Dakota generations: Add Wikipedia reference and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Dodge Dakota
 
+This repository contains signal set configurations for the Dodge Dakota, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Dodge Dakota.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Dodge_Dakota"
+
 generations:
   - name: "First Generation"
     start_year: 1987


### PR DESCRIPTION
- Added references array to generations.yaml with Dodge Dakota Wikipedia URL
- Updated README.md with standard template documentation
- Verified all three generation data (1987-1996, 1997-2004, 2005-2011) matches Wikipedia article
- Wikipedia confirms production dates: 1986-2011 (model years 1987-2011)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
